### PR TITLE
Refactor backend, tests, and schema

### DIFF
--- a/backend/src/graphql/resolvers.ts
+++ b/backend/src/graphql/resolvers.ts
@@ -22,7 +22,33 @@ const JWT_SECRET = process.env.JWT_SECRET; // Use environment variable
 // Assuming your GraphQL context provides prisma client instance
 // e.g. context: { prisma }
 
+import { GraphQLScalarType, Kind } from 'graphql';
+
+const DateTime = new GraphQLScalarType({
+  name: 'DateTime',
+  description: 'A custom DateTime scalar type',
+  serialize(value: any) { // value sent to the client
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    return null;
+  },
+  parseValue(value: any) { // value from the client
+    if (typeof value === 'string') {
+      return new Date(value);
+    }
+    return null;
+  },
+  parseLiteral(ast: any) { // value from the client query
+    if (ast.kind === Kind.STRING) {
+      return new Date(ast.value);
+    }
+    return null;
+  },
+});
+
 export const resolvers = {
+  DateTime, // Add DateTime scalar resolver
   Query: {
     articles: async (
       _: never,

--- a/backend/src/graphql/typeDefs.ts
+++ b/backend/src/graphql/typeDefs.ts
@@ -3,6 +3,7 @@ import { gql } from "apollo-server-express";
 
 export const typeDefs = gql`
   scalar JSON # Added JSON scalar
+  scalar DateTime
 
   type User {
     id: ID!
@@ -44,14 +45,14 @@ export const typeDefs = gql`
     # category: Category! # Assuming relation, might be complex for direct input
     # tags: [Tag!] # Assuming relation
     author: User! # Assuming relation, authorId will be in input or context
-    publishedDate: String # Or DateTime
-    updatedDate: String! # Or DateTime
+    publishedDate: DateTime # Or DateTime
+    updatedDate: DateTime! # Or DateTime
     readTimeMinutes: Int
     isFeatured: Boolean!
     isPublished: Boolean!
     isTopPick: Boolean!
     topPickOrder: Int
-    authorId: String! # Added to match subtask example structure
+    authorId: ID! # Added to match subtask example structure
     primaryCategoryId: String # Added to match subtask example structure
     content: String # Made optional for Markdown content
     blocks: JSON # For block-based editor content
@@ -107,8 +108,8 @@ export const typeDefs = gql`
     primaryCategoryId: String # Optional
     # categoryId: ID! # Replaced by primaryCategoryId to match Article type
     # tagIds: [ID!] # Assuming tags are handled differently or as separate relation mutations
-    # coverImage: String # Already present in Article, should be here too
-    # expertiseLevel: ExpertiseLevel! # Already present in Article, should be here too
+    coverImage: String
+    expertiseLevel: ExpertiseLevel
     content: String # Optional new field
     blocks: JSON # Optional new field
   }

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -3,8 +3,6 @@ import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "../generated/prisma";
 import { User, UserRole, Context } from "../graphql/types";
 
-export const SECRET_KEY: Secret = process.env.JWT_SECRET;
-
 interface TokenPayload {
   userId: string;
 }


### PR DESCRIPTION
This commit addresses several issues raised in the backend code, tests, and GraphQL schema:

- **Backend Testing (`userResolvers.test.ts`):**
    - I refactored `signup` and `login` resolver tests to pass arguments as `{ input: { ... } }`.
    - I updated `prisma.user.create` mock in `signup` test:
        - `username` is now derived from `email.split('@')[0]`.
        - Correctly uses the `select` clause. - `input.name` is no longer incorrectly passed for user creation.
    - `jwt.sign` mock assertions now use a mocked `process.env.JWT_SECRET`.
    - I added `beforeEach` block to set `process.env.JWT_SECRET` for tests.

- **GraphQL Schema (`typeDefs.ts`):**
    - I changed `Article.authorId` type from `String!` to `ID!`.
    - I defined a custom `DateTime` scalar and updated `publishedDate` and `updatedDate` fields in `Article` to use it. Resolver functions for `DateTime` were added to `resolvers.ts`.
    - I uncommented and included `coverImage: String` and `expertiseLevel: ExpertiseLevel` in `ArticleInput` to make them mutable.

- **Backend Code (`auth.ts`):**
    - I removed the unused `SECRET_KEY` constant as `jwtSecret` is passed directly to `getUserFromToken`.